### PR TITLE
Add routing class

### DIFF
--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -1,0 +1,50 @@
+from collections import defaultdict
+import networkx as nx
+
+class Routing():
+    def __init__(self, topo, rproto):
+        path_fn = None
+
+        if rproto == 'kshort':
+            path_fn = self.k_shortest_paths
+        elif rproto == 'ecmp':
+            path_fn = self.ecmp_paths
+
+        if not path_fn: raise Exception('Unknown routing protocol')
+
+        self.rtable = self.generate_dports(topo, path_fn)
+
+    def k_shortest_paths(self, g, src, dst):
+        paths = list(nx.all_simple_paths(g, src, dst))
+        return sorted(paths, key=lambda p: len(p))
+
+    def ecmp_paths(self, g, src, dst):
+        return list(nx.all_shortest_paths(g, src, dst))
+
+    # Creates routing table:
+    # switch_id -> (node_id -> [egress ports])
+    def generate_dports(self, topo, path_fn):
+        rtable = defaultdict(lambda: dict())
+
+        # create map from node name -> (node name -> egress port)
+        links = topo.links(withInfo=True)
+        port_map = defaultdict(lambda: dict())
+        for l in links:
+            port_map[l[0]][l[1]] = l[2]['port1']
+            port_map[l[1]][l[0]] = l[2]['port2']
+
+        switches = topo.switches()
+        g = nx.Graph()
+        g.add_nodes_from(topo.nodes())
+        g.add_edges_from(topo.links())
+
+        # find paths from each switch to each node
+        for src in switches:
+            for dst in filter(lambda n: n != src, topo.nodes()):
+                paths = path_fn(g, src, dst)
+                # all protos use 8 as max paths for now
+                if len(paths) > 8: paths = paths[:8]
+                # convert paths to egress ports
+                rtable[src][dst] = [port_map[src][p[1]] for p in paths]
+
+        return rtable

--- a/pox/pox/ext/topologies.py
+++ b/pox/pox/ext/topologies.py
@@ -62,8 +62,8 @@ class JellyfishTopo(Topo):
             if possible:
                 l = possible[0]
                 self.temp_links.remove(l)
-                self.temp_links.add((s, l[0]))
-                self.temp_links.add((s, l[1]))
+                self.temp_links.append((s, l[0]))
+                self.temp_links.append((s, l[1]))
 
     def find_available_pairs(self):
         avail = filter(lambda s: self.switch_ports_remaining[s] > 0, self.switches())
@@ -113,3 +113,11 @@ class FatTreeTopo(Topo):
     pass
 
 topologies = {'ft': FatTreeTopo, 'jelly': JellyfishTopo, 'dummy': DummyTopo}
+
+from routing import Routing
+
+if __name__ == '__main__':
+    # Create Jellyfish Topology
+    topo = JellyfishTopo()
+    routing = Routing(topo, 'kshort')
+    for i in routing.rtable.items(): print(i)


### PR DESCRIPTION
The routing class can implement ECMP or k-shortest paths for the topology.
Both at present use 8 for the max number of paths.
Routing creates a map from node id -> node id -> egress ports. Meaning, given the id
of the current node and the id of the destination node, we have a list of egress
ports for the paths. This should not remove duplicates (if there are multiple shortest
paths out of the same egress port, that egress port should appear in the list multiple times)