### PR TITLE
set mac addresses of hosts to match their dpid

### DIFF
--- a/pox/pox/ext/jellyfish_controller.py
+++ b/pox/pox/ext/jellyfish_controller.py
@@ -142,5 +142,6 @@ def launch (topo=None, routing=None):
     raise Exception("Topology and Routing mechanism must be specified.")
 
   my_topology = build_topology(topo)
-  my_routing = Routing(my_topology, routing)
+  my_routing = Routing(my_topology, routing, log)
+  log.info("Launching routing")
   core.registerNew(JellyfishController, my_topology, my_routing)

--- a/pox/pox/ext/utils.py
+++ b/pox/pox/ext/utils.py
@@ -28,3 +28,6 @@ def build_topology(topo):
 
 def dpid_to_str(dpid):
     return "s%d" % dpid
+
+def node_name_to_dpid(host_name):
+    return int(host_name[1:])

--- a/pox/pox/ext/utils.py
+++ b/pox/pox/ext/utils.py
@@ -28,6 +28,3 @@ def build_topology(topo):
 
 def dpid_to_str(dpid):
     return "s%d" % dpid
-
-def node_name_to_dpid(host_name):
-    return int(host_name[1:])


### PR DESCRIPTION
- A potential solution to the host identification problem
- The routing class now can map host Ethernet addresses to host names

Solution: At topology-creation we set the MAC addresses of the host to be exactly their dpid.  We can then deduce MAC addresses in the controller.

Potential problem: I think there is a very low probability of assigning a duplicate MAC address to some switch in the topology

Potential problem 2: We may need to map from (MAC address, port) to name for switches and hosts, not just hosts