### PR TITLE
Use routing to set egress ports

### DIFF
--- a/pox/pox/ext/controllers.py
+++ b/pox/pox/ext/controllers.py
@@ -6,7 +6,7 @@ POXDIR = os.getcwd() + '/../..'
 class JellyfishController( Controller ):
     def __init__( self, name, cdir=POXDIR,
                   command='python pox.py',
-                  cargs=('log --file=jelly.log,w openflow.of_01 --port=%s ext.jellyfish_controller --topo=dummy,0 --routing=ecmp' ),
+                  cargs=('log --file=jelly.log,w openflow.of_01 --port=%s ext.jellyfish_controller --topo=jelly,0 --routing=ecmp' ),
                   **kwargs ):
           # TODO: how to propagate the topology/routing to the cmd above
         Controller.__init__( self, name, cdir=cdir,

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -6,7 +6,7 @@ import networkx as nx
 import itertools
 import random
 
-from topologies import dpid_to_mac_addr, node_name_to_dpid
+from topologies import dpid_to_mac_addr, node_name_to_dpid, dpid_to_switch
 import pox.openflow.libopenflow_01 as of
 
 import yens
@@ -18,17 +18,17 @@ class Routing():
 
         self.set_path_fn(rproto)
 
-        self.mac_to_hostname = {} # Maps host MAC addresses to hostnames.
+        self.hostname_to_mac = {} # Maps hostnames to mac addresses.
         for host in topo.hosts():
-            self.mac_to_hostname[dpid_to_mac_addr(node_name_to_dpid(host))] = host
-        self.log.info(self.mac_to_hostname)
+            self.hostname_to_mac[host] = dpid_to_mac_addr(node_name_to_dpid(host))
+        self.log.info(self.hostname_to_mac)
 
     def set_path_fn(self, rproto):
         self.path_fn = None
 
         if rproto == 'kshort': # use 8 as k
             self.path_fn = partial(self.k_shortest_paths, k=8)
-        elif rproto == 'ecmp8':
+        elif rproto == 'ecmp8' or rproto == 'ecmp':
             self.path_fn = partial(self.ecmp_paths, k=8)
         elif rproto == 'ecmp64':
             self.path_fn = partial(self.ecmp_paths, k=64)
@@ -36,7 +36,7 @@ class Routing():
         if not self.path_fn: raise Exception('Unknown routing protocol')
 
     def generate_rtable(self):
-        self.rtable = self.generate_dports(topo, path_fn)
+        self.generate_routing_paths()
 
     def k_shortest_paths(self, g, src, dst, k=8):
         return yens.k_shortest_paths(g, src, dst, k)[1]
@@ -46,31 +46,32 @@ class Routing():
         if len(paths) > k: paths = paths[:k]
         return paths
 
-    # Creates routing table:
-    # switch_id -> (node_id -> [egress ports])
-    def generate_dports(self, topo, path_fn):
-        rtable = defaultdict(lambda: dict())
+    # Creates path map:
+    # host src eth -> (host src eth -> [possible paths])
+    def generate_routing_paths(self):
+        self.routing_paths = defaultdict(lambda: dict())
 
         # create map from node name -> (node name -> egress port)
-        links = topo.links(withInfo=True)
-        port_map = defaultdict(lambda: dict())
+        links = self.topo.links(withInfo=True)
+        self.port_map = defaultdict(lambda: dict())
         for l in links:
-            port_map[l[0]][l[1]] = l[2]['port1']
-            port_map[l[1]][l[0]] = l[2]['port2']
+            self.port_map[l[0]][l[1]] = l[2]['port1']
+            self.port_map[l[1]][l[0]] = l[2]['port2']
 
-        switches = self.topo.switches()
+        hosts = self.topo.hosts()
         g = nx.Graph()
         g.add_nodes_from(self.topo.nodes())
         g.add_edges_from(self.topo.links())
 
-        # find paths from each switch to each node
-        for src in switches:
-            for dst in filter(lambda n: n != src, topo.nodes()):
+        # find paths from each host to each host
+        # note: we do not know how to route to other switches, only other hosts
+        for src in hosts:
+            for dst in filter(lambda h: h != src, hosts):
                 paths = self.path_fn(g, src, dst)
                 # convert paths to egress ports
-                rtable[src][dst] = [port_map[src][p[1]] for p in paths]
-
-        return rtable
+                src_mac = self.hostname_to_mac[src]
+                dst_mac = self.hostname_to_mac[dst]
+                self.routing_paths[src_mac][dst_mac] = paths
 
     # generates paths for random permutation traffic
     # (each host connected to only one other host)
@@ -104,9 +105,40 @@ class Routing():
                 edge_counts[e] += 1
         return edge_counts
 
+    def _ecmp_hash(self, packet):
+        "Return an ECMP-style 5-tuple hash for TCP/IP packets, otherwise 0."
+        hash_input = [0] * 5
+        if isinstance(packet.next, ipv4):
+          ip = packet.next
+          hash_input[0] = ip.srcip.toUnsigned()
+          hash_input[1] = ip.dstip.toUnsigned()
+          hash_input[2] = ip.protocol
+          if isinstance(ip.next, tcp) or isinstance(ip.next, udp):
+            l4 = ip.next
+            hash_input[3] = l4.srcport
+            hash_input[4] = l4.dstport
+            return crc32(pack('LLHHH', *hash_input))
+        return 0
+
+    # get paths between src and dst mac address of packet
+    # choose path deterministically based on hash from packet data
+    # find current switch in path, and find egress port to get
+    # to next hop in the path
     def get_egress_port(self, packet, switch_dpid):
-        return of.OFPP_FLOOD
-        pass # TODO: implement.
+        if str(packet.dst) == 'ff:ff:ff:ff:ff:ff':
+            self.log.info('Broadcasting packet')
+            return of.OFPP_FLOOD
+
+        paths = self.routing_paths[str(packet.src)][str(packet.dst)]
+        """
+        TODO: get proper ECMP hashing working
+        index = len(paths) % self._ecmp_hash(packet)
+        path = paths[index]
+        """
+        path = random.choice(paths)
+        switch_id = dpid_to_switch(switch_dpid)
+        switch_index = path.index(switch_id)
+        return self.port_map[switch_id][path[switch_index + 1]]
 
     def register_switch(self, switch):
         """

--- a/pox/pox/ext/run.py
+++ b/pox/pox/ext/run.py
@@ -22,7 +22,7 @@ from time import sleep, time
 # These two map strings to class constructors for
 # controllers and topologies.
 from pox.ext.controllers import JellyfishController
-from topologies import topologies
+from topologies import topologies, dpid_to_ip_addr
 
 def test_ping(net):
     """
@@ -125,6 +125,9 @@ def rand_perm_traffic(net, P=1, rounds=5):
     finally:
         net.stop()
         print(host_throughput) # values in GBits/s
+        avg_throughput = float(sum(host_throughput.values())) / len(host_throughput.items())
+        # TODO: figure out actual nic rate
+        print('Average throughput: {}, Percentage of NIC rate: {}'.format(avg_throughput, avg_throughput/10.0))
 
 # Set up argument parser.
 
@@ -152,6 +155,15 @@ if __name__ == '__main__':
 
     # Create Mininet network with a custom controller
     net = Mininet(topo=topo, controller=JellyfishController)#, host=CPULimitedHost, link=TCLink) TODO: why do these arguments fail?
+
+    """
+    NOTE: to set the IPs of the switches you can do
+    for n in net.switches:
+        n.setIP(dpid_to_ip_addr(int(n.dpid)))
+    However, this currently causes a weird crash in core, such that
+    the line core.registerNew(JellyfishController, my_topology, my_routing)
+    in jellyfish_controller.py never seems to finish executing
+    """
 
     if args['pingtest']:
         # Run ping all experiment


### PR DESCRIPTION
Maintains list of paths between each pair of hosts and uses it to
set the egress port by finding a path from the src/dst mac of the packet,
finding where the current router is on the path, and determining out of which
port the next hop on the path is.

Currently does not use proper ecmp hashing and randomly chooses a path
because the riplpox ecmp hash doesn't work out of the box. We need to do this.

The dummy topology can pingall, but the Jellyfish topology is struggling
apparently because of DHCP packets being too short? I have been trying to
manually set IPs of switches to no avail.