### PR TITLE
Alanefl/pingall works on jelly

### DIFF
--- a/pox/pox/ext/controllers.py
+++ b/pox/pox/ext/controllers.py
@@ -5,8 +5,9 @@ POXDIR = os.getcwd() + '/../..'
 
 class JellyfishController( Controller ):
     def __init__( self, name, cdir=POXDIR,
-                  command='python pox.py',
-                  cargs=('log --file=jelly.log,w openflow.of_01 --port=%s ext.jellyfish_controller --topo=jelly,0 --routing=ecmp' ),
+                  command='python debug-pox.py',
+                  cargs=("log --file=jelly.log,w log.level --packet=WARN openflow.of_01 --port=%s "
+                          "ext.jellyfish_controller --topo=jelly,0 --routing=ecmp" ),
                   **kwargs ):
           # TODO: how to propagate the topology/routing to the cmd above
         Controller.__init__( self, name, cdir=cdir,

--- a/pox/pox/ext/controllers.py
+++ b/pox/pox/ext/controllers.py
@@ -6,7 +6,7 @@ POXDIR = os.getcwd() + '/../..'
 class JellyfishController( Controller ):
     def __init__( self, name, cdir=POXDIR,
                   command='python pox.py',
-                  cargs=('log --file=jelly.log,w openflow.of_01 --port=%s ext.jellyfish_controller --topo=dummy,0 --routing=ecmp' ),
+                  cargs=('log --file=jelly.log,w openflow.of_01 --port=%s ext.jellyfish_controller --topo=dummy,0 --routing=kshort' ),
                   **kwargs ):
           # TODO: how to propagate the topology/routing to the cmd above
         Controller.__init__( self, name, cdir=cdir,

--- a/pox/pox/ext/figure9.py
+++ b/pox/pox/ext/figure9.py
@@ -49,8 +49,11 @@ def figure9():
     plt.ylabel('# Distinct Paths Link is on')
     plt.xlabel('Rank of Link')
 
+    print("Started analyzing kshort paths...")
     plot_line(topo, 'kshort', '8 Shortest Paths', 'blue', linewidth=7)
+    print("Finished kshort. Starting ecmp8...")
     plot_line(topo, 'ecmp8', '8-way ECMP', 'olive')
+    print("Finished ecmp64. Starting ecmp64...")
     plot_line(topo, 'ecmp64', '64-way ECMP', 'red', linestyle=':')
 
     plt.legend(loc=2)

--- a/pox/pox/ext/jellyfish_controller.py
+++ b/pox/pox/ext/jellyfish_controller.py
@@ -67,7 +67,6 @@ class JellyfishController (EventMixin):
     Is called whenever a switch in the Mininet topoplogy comes up,
     and registers it in the controller.
     """
-
     switch_dpid = event.dpid
     switch = self.switches.get(event.dpid)
 
@@ -135,7 +134,7 @@ def launch (topo=None, routing=None):
           e.g.: 'jellyfish,4' 'dummy'
 
       - routing is a string indicating what routing mechanism to use:
-          e.g.: 'ecmp', 'kshort'
+          e.g.: 'ecmp8', 'kshort'
   """
   log.info("Launching controller")
   if not topo or not routing:
@@ -145,3 +144,4 @@ def launch (topo=None, routing=None):
   my_routing = Routing(my_topology, routing, log)
   log.info("Launching routing")
   core.registerNew(JellyfishController, my_topology, my_routing)
+  log.info("Registered Jellyfish controller and routing")

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -126,8 +126,10 @@ class Routing():
     # find current switch in path, and find egress port to get
     # to next hop in the path
     def get_egress_port(self, packet, switch_dpid):
+
+        # This should actually never happen.
         if str(packet.dst) == 'ff:ff:ff:ff:ff:ff':
-            self.log.info('Broadcasting packet')
+            self.log.warn('Broadcasting packet..')
             return of.OFPP_FLOOD
 
         paths = self.routing_paths[str(packet.src)][str(packet.dst)]

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -137,7 +137,14 @@ class Routing():
         path = paths[index]
         """
         path = random.choice(paths)
+
         switch_id = dpid_to_switch(switch_dpid)
+
+        # NOTE: we must choose a path that contains the current
+        #       switch.
+        while switch_id not in path:
+            path = random.choice(paths)
+
         switch_index = path.index(switch_id)
         return self.port_map[switch_id][path[switch_index + 1]]
 

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -16,6 +16,7 @@ class Routing():
         self.topo = topo
         self.log = log
 
+        self.log.info("Setting proto")
         self.set_path_fn(rproto)
 
         self.mac_to_hostname = {} # Maps host MAC addresses to hostnames.

--- a/pox/pox/ext/topologies.py
+++ b/pox/pox/ext/topologies.py
@@ -30,18 +30,21 @@ class JellyfishTopo(Topo):
         # add n switches, each attached to k hosts
         # The number x in (s|h)x must be globally unique
         # across the topology.
+        #
+        # We assign a pid incrementally to every switch or host that comes up.
+        pid_ctr = 1
         for i in range(1,n+1): # so that i is not 0
-            sdpid = 2*i
             """
             NOTE: setting the IP of the switch here doesn't seem to do anything,
                   though the IP of the host is set.
             """
-            s = self.addSwitch('s{}'.format(sdpid), ip=dpid_to_ip_addr(sdpid))
+            s = self.addSwitch('s{}'.format(pid_ctr))
+            pid_ctr += 1
             for j in range(k-r):
-                hdpid = 2*i + 1
-                h = self.addHost('h{}'.format(hdpid), mac=dpid_to_mac_addr(hdpid),
-                    ip=dpid_to_ip_addr(hdpid))
+                h = self.addHost('h{}'.format(pid_ctr), mac=dpid_to_mac_addr(pid_ctr),
+                    ip=dpid_to_ip_addr(pid_ctr))
                 self.addLink(h, s)
+                pid_ctr += 1
             # Note: to actually add the ports to the switch, we could use
             #       map(s.attach, range(NUM_PORTS))
             #       however, switch numbers don't matter, only the number of
@@ -153,8 +156,12 @@ def dpid_to_mac_addr(dpid):
     return ':'.join(s.encode('hex') for s in interm.decode('hex'))
 
 def dpid_to_ip_addr(dpid):
+    """
+    Returns 10.0.0.<dpid>
+    """
     import socket, struct
-    return socket.inet_ntoa(struct.pack('!L', dpid))
+    addr = socket.inet_ntoa(struct.pack('!L', dpid))
+    return "10" + addr[1:]
 
 def node_name_to_dpid(host_name):
     return int(host_name[1:])


### PR DESCRIPTION
- Sets the IP addresses of hosts to `10.0.0.<dpid>` instead of `0.0.0.<dpid>`.  The latter was making hosts think that other hosts were not in the same subnet, so no ARP entries were being installed. 
- Ignores all broadcast messages received on any switch.  These are DHCP requests, and we don't need to handle them.  TODO: is there a way to prevent DHCP messages from being sent?
- Sets ARP entries for all hosts after creating the mininet topology, so that every host knows the MAC address of every other host
- Modifies the routing logic to ensure that the random path chosen for the current packet actually contains the current switch

TODO: 
 - get the ECMP hashing to work correctly, so that the routing is 100% correct
  - once this is done, run the rand perm traffic tests and ensure that we can get OK figures, given that some things can potentially be automated. e.g. currently the controller is invoked to make every single forwarding decision.  We could also install flow tables in each switch once, making things faster.  Not sure if this will have an effect on performance or not. 
- Figure out the exact NIC rate. 
- The flow table entries should be based on a hash, not on the first egress port that is chosen