### PR TITLE
Alanefl/easy test arguments

### DIFF
--- a/pox/pox/ext/controllers.py
+++ b/pox/pox/ext/controllers.py
@@ -6,10 +6,10 @@ POXDIR = os.getcwd() + '/../..'
 class JellyfishController( Controller ):
     def __init__( self, name, cdir=POXDIR,
                   command='python pox.py',
-                  cargs=("log --file=jelly.log,w log.level openflow.of_01 --port=%s "
-                          "ext.jellyfish_controller --topo=jelly,0 --routing=ecmp" ),
+                  cargs=None,
                   **kwargs ):
-          # TODO: how to propagate the topology/routing to the cmd above
+        cargs = ("log --file=jelly.log,w log.level openflow.of_01 --port=%s "
+                  "ext.jellyfish_controller" )
         Controller.__init__( self, name, cdir=cdir,
                              command=command,
                              cargs=cargs, **kwargs )

--- a/pox/pox/ext/controllers.py
+++ b/pox/pox/ext/controllers.py
@@ -5,8 +5,8 @@ POXDIR = os.getcwd() + '/../..'
 
 class JellyfishController( Controller ):
     def __init__( self, name, cdir=POXDIR,
-                  command='python debug-pox.py',
-                  cargs=("log --file=jelly.log,w log.level --packet=WARN openflow.of_01 --port=%s "
+                  command='python pox.py',
+                  cargs=("log --file=jelly.log,w log.level openflow.of_01 --port=%s "
                           "ext.jellyfish_controller --topo=jelly,0 --routing=ecmp" ),
                   **kwargs ):
           # TODO: how to propagate the topology/routing to the cmd above

--- a/pox/pox/ext/jellyfish_controller.py
+++ b/pox/pox/ext/jellyfish_controller.py
@@ -212,7 +212,7 @@ def launch ():
   # Read out configuration from file.
 
   # NOTE: assumes jellyfish has been installed in the home directory.
-  config_loc = os.environ['HOME'] + '/jellyfish/pox/pox/ext/__jellyconfig'
+  config_loc = 'pox/ext/__jellyconfig'
   with open(config_loc, 'r', os.O_NONBLOCK) as config_file:
     log.info("inside")
     n = int(config_file.readline().split('=')[1])

--- a/pox/pox/ext/jellyfish_controller.py
+++ b/pox/pox/ext/jellyfish_controller.py
@@ -18,7 +18,6 @@ JellyfishController class.
 
 import sys
 import os
-from os.path import expanduser
 sys.path.append("../../")
 from pox.core import core
 from pox.lib.util import dpidToStr
@@ -213,7 +212,7 @@ def launch ():
   # Read out configuration from file.
 
   # NOTE: assumes jellyfish has been installed in the home directory.
-  config_loc = expanduser("~") + '/jellyfish/pox/pox/ext/__jellyconfig'
+  config_loc = os.environ['HOME'] + '/jellyfish/pox/pox/ext/__jellyconfig'
   with open(config_loc, 'r', os.O_NONBLOCK) as config_file:
     log.info("inside")
     n = int(config_file.readline().split('=')[1])

--- a/pox/pox/ext/parse_out.py
+++ b/pox/pox/ext/parse_out.py
@@ -1,0 +1,18 @@
+#
+# Takes the output file from a test run and displays it nicely.
+#
+
+percentages = []
+with open('test_out', 'r') as out:
+    for line in out:
+      if line.startswith('Percentage of NIC rate:'):
+        percentages.append(line.split()[-1])
+
+experiment_order = ['TCP 1 Flow  w/   8ECMP',
+                    'TCP 8 Flows w/   8ECMP',
+                    'TCP 1 Flow  w/ 8KSHORT',
+                    'TCP 8 Flows w/ 8KSHORT']
+
+print("\n\n ~~ Final Results: Table 1 ~~")
+for idx, p in enumerate(percentages):
+  print("\t%s --> %s" % (experiment_order[idx], p))

--- a/pox/pox/ext/parse_out.py
+++ b/pox/pox/ext/parse_out.py
@@ -13,6 +13,6 @@ experiment_order = ['TCP 1 Flow  w/   8ECMP',
                     'TCP 1 Flow  w/ 8KSHORT',
                     'TCP 8 Flows w/ 8KSHORT']
 
-print("\n\n ~~ Final Results: Table 1 ~~")
+print("\n\n ~~ Final Results: Table 1 ~~\n")
 for idx, p in enumerate(percentages):
-  print("\t%s --> %s" % (experiment_order[idx], p))
+  print("    %s --> %s" % (experiment_order[idx], p))

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -5,6 +5,9 @@ from functools import partial
 import networkx as nx
 import itertools
 import random
+from pox.lib.packet import ipv4, tcp, udp
+from struct import pack
+from zlib import crc32
 
 from topologies import dpid_to_mac_addr, node_name_to_dpid, dpid_to_switch
 import pox.openflow.libopenflow_01 as of
@@ -23,6 +26,8 @@ class Routing():
         for host in topo.hosts():
             self.hostname_to_mac[host] = dpid_to_mac_addr(node_name_to_dpid(host))
         self.log.info(self.hostname_to_mac)
+
+        random.seed(0)
 
     def set_path_fn(self, rproto):
         self.path_fn = None
@@ -133,20 +138,11 @@ class Routing():
             return of.OFPP_FLOOD
 
         paths = self.routing_paths[str(packet.src)][str(packet.dst)]
-        """
-        TODO: get proper ECMP hashing working
-        index = len(paths) % self._ecmp_hash(packet)
+
+        # ECMP hash.
+        index = self._ecmp_hash(packet) % len(paths)
         path = paths[index]
-        """
-        path = random.choice(paths)
-
         switch_id = dpid_to_switch(switch_dpid)
-
-        # NOTE: we must choose a path that contains the current
-        #       switch.
-        while switch_id not in path:
-            path = random.choice(paths)
-
         switch_index = path.index(switch_id)
         return self.port_map[switch_id][path[switch_index + 1]]
 

--- a/pox/pox/ext/routing.py
+++ b/pox/pox/ext/routing.py
@@ -15,7 +15,7 @@ import pox.openflow.libopenflow_01 as of
 import yens
 
 class Routing():
-    def __init__(self, topo, rproto, log):
+    def __init__(self, topo, rproto, log, seed=0):
         self.topo = topo
         self.log = log
 
@@ -27,7 +27,7 @@ class Routing():
             self.hostname_to_mac[host] = dpid_to_mac_addr(node_name_to_dpid(host))
         self.log.info(self.hostname_to_mac)
 
-        random.seed(0)
+        random.seed(seed)
 
     def set_path_fn(self, rproto):
         self.path_fn = None

--- a/pox/pox/ext/run.py
+++ b/pox/pox/ext/run.py
@@ -103,7 +103,7 @@ def monitor_throughput(popens, P, rounds, host_throughput):
             else:
                 if '[SUM]' in line:
                     host_lines[host.name] = line.strip()
-            print("<%s>: %s" % (host.name, line.strip()))
+            #print("<%s>: %s" % (host.name, line.strip()))
 
     # Update the per-server throughput values after each round.
     update_server_throughputs(host_lines, host_throughput, rounds)
@@ -177,7 +177,7 @@ def rand_perm_traffic(net, P=1, rounds=5):
         # NOTE: we are setting the NIC rate by specifying the bandwidth
         #       field of each TCLink object.
         print('Average server throughput: {}'.format(avg_throughput))
-        print('Percentage of NIC rate: {:.1%}%'.format(avg_throughput/NIC_RATE))
+        print('Percentage of NIC rate: {:.1%}'.format(avg_throughput/NIC_RATE))
 
 def print_switches(net, n_interfaces=3):
     """

--- a/pox/pox/ext/table1.sh
+++ b/pox/pox/ext/table1.sh
@@ -1,50 +1,30 @@
 #
-# Runs the experiments to generate Table 1 on Jellyfish paper.
+# Runs the experiments to generate a subset of Table 1 on Jellyfish paper.
 #
 
-# NOTE: I am assuming a NIC output rate of 10 GBps
-#       based on the command:
-#         mininet> dpctl dump-ports-desc
 
-#
-# NOTE: my current plan is to run IPERF client and servers and
-#       all machine pairs, and use that to measure throughput.
-#
-#       I need to set up iperf servers on the targets, and iperf
-#       clients on the sending hosts.  I can use the -P flag
-#       to tell a host how many flows to send in parallel.
-#
-#    TODO: can we use monitor functions from mininet to do this easily?
-#
+echo '**** Running test: random permutation traffic, 1 TCP flow, ECMP ****'
 
-# NOTE: assumes TCP default congestion control is cubic or reno.
-
-echo '**** Running test: random permutation traffic, 1 TCP flow ****'
 # 1. Run random permutation traffic test on Jellyfish topology with
-#    780 servers. With congestion control: TCP 1 flow
-#
-#    TODO: actually support this with jellyfish.  This is a placeholder.
-sudo sysctl -w net.mptcp.mptcp_enabled=0 # Turn off MPTCP
-sudo python run.py -randpermtraffic --flows 1 -t dummy
-
+#    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp
 
 exit
 
-echo '**** Running test: random permutation traffic, 8 TCP flows ****'
-# 2. Run random permutation traffic test on Jellyfish topology with
-#    780 servers. With congestion control: TCP 8 flows
-#    TODO: actually support this with jellyfish.  This is a placeholder.
-sudo python run.py -randpermtraffic --flows 8 -t dummy
+echo '**** Running test: random permutation traffic, 8 TCP flows, ECMP ****'
 
-# NOTE: Using MPTCP as described here:
-#    - https://multipath-tcp.org/pmwiki.php/Users/AptRepository
-#
-#      Reference for getting MPTCP to work: https://github.com/bocon13/mptcp_setup
-#
+# 2. Run random permutation traffic test on Jellyfish topology with
+#    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp
+
+echo '**** Running test: random permutation traffic, 1 TCP flow, KSHORT ****'
+
 # 3. Run random permutation traffic test on Jellyfish topology with
-#    780 servers. With congestion control: MPTCP 8 subflows
-#
-#    TODO: actually support this with jellyfish.  This is a placeholder.
-sudo sysctl -w net.mptcp.mptcp_enabled=1 # Turn on MPTCP
-sudo python run.py -randpermtraffic --flows 8 -t dummy
-sudo sysctl -w net.mptcp.mptcp_enabled=0 # Turn off MPTCP again
+#    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort
+
+echo '**** Running test: random permutation traffic, 8 TCP flows, KSHORT ****'
+
+# 4. Run random permutation traffic test on Jellyfish topology with
+#    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort

--- a/pox/pox/ext/table1.sh
+++ b/pox/pox/ext/table1.sh
@@ -5,9 +5,11 @@
 
 echo '**** Running test: random permutation traffic, 1 TCP flow, ECMP ****'
 
+rm test_out
+
 # 1. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0
+sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0 | tee test_out
 
 exit
 
@@ -15,16 +17,19 @@ echo '**** Running test: random permutation traffic, 8 TCP flows, ECMP ****'
 
 # 2. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0
+sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0 | tee test_out
 
 echo '**** Running test: random permutation traffic, 1 TCP flow, KSHORT ****'
 
 # 3. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0
+sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0 | tee test_out
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, KSHORT ****'
 
 # 4. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0
+sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0 | tee test_out
+
+python parse_out.py
+rm test_out

--- a/pox/pox/ext/table1.sh
+++ b/pox/pox/ext/table1.sh
@@ -6,30 +6,30 @@
 echo '**** Running test: random permutation traffic, 1 TCP flow, ECMP ****'
 
 rm test_out
+sudo mn -c
 
 # 1. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0 | tee test_out
+sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0 > test_out
 
-exit
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, ECMP ****'
 
 # 2. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0 | tee test_out
+sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0 > test_out
 
 echo '**** Running test: random permutation traffic, 1 TCP flow, KSHORT ****'
 
 # 3. Run random permutation traffic test on Jellyfish topology with
-#    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0 | tee test_out
+#    n=10, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0 > test_out
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, KSHORT ****'
 
 # 4. Run random permutation traffic test on Jellyfish topology with
-#    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0 | tee test_out
+#    n=10, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
+sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0 > test_out
 
 python parse_out.py
 rm test_out

--- a/pox/pox/ext/table1.sh
+++ b/pox/pox/ext/table1.sh
@@ -10,26 +10,26 @@ sudo mn -c
 
 # 1. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0 > test_out
+sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0 >> test_out
 
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, ECMP ****'
 
 # 2. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0 > test_out
+sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0 >> test_out
 
 echo '**** Running test: random permutation traffic, 1 TCP flow, KSHORT ****'
 
 # 3. Run random permutation traffic test on Jellyfish topology with
 #    n=10, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0 > test_out
+sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0 >> test_out
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, KSHORT ****'
 
 # 4. Run random permutation traffic test on Jellyfish topology with
 #    n=10, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0 > test_out
+sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0 >> test_out
 
 python parse_out.py
 rm test_out

--- a/pox/pox/ext/table1.sh
+++ b/pox/pox/ext/table1.sh
@@ -7,7 +7,7 @@ echo '**** Running test: random permutation traffic, 1 TCP flow, ECMP ****'
 
 # 1. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp
+sudo python run.py -randpermtraffic --flows 1 -t jelly,25,4,3 --routing ecmp --seed 0
 
 exit
 
@@ -15,16 +15,16 @@ echo '**** Running test: random permutation traffic, 8 TCP flows, ECMP ****'
 
 # 2. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp
+sudo python run.py -randpermtraffic --flows 8 -t jelly,25,4,3 --routing ecmp --seed 0
 
 echo '**** Running test: random permutation traffic, 1 TCP flow, KSHORT ****'
 
 # 3. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 1 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort
+sudo python run.py -randpermtraffic --flows 1 -t jelly,10,4,3 --routing kshort --seed 0
 
 echo '**** Running test: random permutation traffic, 8 TCP flows, KSHORT ****'
 
 # 4. Run random permutation traffic test on Jellyfish topology with
 #    n=25, k=4, r=3. With congestion control: TCP 8 flows, Routing: ECMP
-sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort
+sudo python run.py -randpermtraffic --flows 8 -t jelly,10,4,3 --routing kshort --seed 0

--- a/pox/pox/ext/topologies.py
+++ b/pox/pox/ext/topologies.py
@@ -19,9 +19,6 @@ class JellyfishTopo(Topo):
     def build(self, random_seed=0, n=15, k=NUM_PORTS, r=None):
         if r is None: r = k-1
 
-       # n = 8
-        # k = 6
-        # r = 4
 
         # For reproducing the topology in the controller and in the
         # Mininet instance.

--- a/pox/pox/ext/topologies.py
+++ b/pox/pox/ext/topologies.py
@@ -7,7 +7,8 @@ Keep all topology definitions for PA2 in this file.
 
 """
 
-NUM_PORTS = 3
+NUM_PORTS = 4
+BW = 10
 
 class JellyfishTopo(Topo):
     """
@@ -15,8 +16,12 @@ class JellyfishTopo(Topo):
     r of which are connected to other switches.
     They are connected to each other using the jellyfish algorithm
     """
-    def build(self, random_seed=0, n=4, k=NUM_PORTS, r=None):
+    def build(self, random_seed=0, n=15, k=NUM_PORTS, r=None):
         if r is None: r = k-1
+
+       # n = 8
+        # k = 6
+        # r = 4
 
         # For reproducing the topology in the controller and in the
         # Mininet instance.
@@ -43,7 +48,7 @@ class JellyfishTopo(Topo):
             for j in range(k-r):
                 h = self.addHost('h{}'.format(pid_ctr), mac=dpid_to_mac_addr(pid_ctr),
                     ip=dpid_to_ip_addr(pid_ctr))
-                self.addLink(h, s)
+                self.addLink(h, s, bw=BW)
                 pid_ctr += 1
             # Note: to actually add the ports to the switch, we could use
             #       map(s.attach, range(NUM_PORTS))
@@ -56,7 +61,7 @@ class JellyfishTopo(Topo):
         self.make_jellyfish_topo()
 
         # since there is not actual removeLink method, only add links at the end
-        for l in self.temp_links: self.addLink(*l)
+        for l in self.temp_links: self.addLink(*l, bw=BW)
 
     def make_jellyfish_topo(self):
         # while possible, join two random switches with free ports


### PR DESCRIPTION
- Contains `table1.sh` script that in one single place runs the experiments required (there may be some missing file errors, but they don't affect the correctness of the script)
- Adds all the logic in the ecmp-hashing branch
- Uses a write-to-file mechanism for sharing arguments (not pretty, but it works)

NOTE: we can now only run tests on Jellyfish topologies now!
NOTE2: the cmd line arguments to run tests has changed.  see `table.sh` for examples. 